### PR TITLE
Added a selenium smoke test which logs into the backpack via browserid. ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 !/static/.gitkeep
 /test.json
 /bin/badges.json
+/test/acceptance/local-config.js

--- a/test/acceptance/local-config.js.sample
+++ b/test/acceptance/local-config.js.sample
@@ -1,0 +1,6 @@
+exports.config = {
+  /* Email for login via BrowserID. */
+  email: 'example@example.com'
+  /* Password for login via BrowserID. */
+, password: 'example'
+};

--- a/test/acceptance/smoke-test.js
+++ b/test/acceptance/smoke-test.js
@@ -1,0 +1,51 @@
+var soda = require('soda'),
+    config = require('./local-config').config;
+
+var browser = soda.createClient({
+    host: config.host || 'localhost'
+  , port: config.port || 4444
+  , url: config.url || 'http://localhost:8888'
+  , browser: config.browser || 'firefox'
+});
+
+browser.on('command', function(cmd, args){
+  console.log(' \x1b[33m%s\x1b[0m: %s', cmd, args.join(', '));
+});
+
+function scriptify(func) {
+  var code = '(' + func.toString() + ')' +
+             '(selenium.browserbot.getCurrentWindow());';
+  return code;
+}
+
+soda.prototype.logIntoBrowserID = function(email, password) {
+  return this.waitForPopUp(null, 8000)
+    .selectWindow('title=BrowserID')
+    .waitForElementPresent('css=input#email')
+    .type('css=input#email', email)
+    .click('css=button.start')
+    .waitForCondition(scriptify(function(window) {
+      var active = window.document.activeElement;
+      var passwordField = window.document.querySelector("input#password");
+      return active === passwordField;
+    }), 3000)
+    .type('css=input#password', password)
+    .click('css=button.returning:enabled')
+    .waitForElementPresent('css=button#signInButton')
+    .click('css=button#signInButton:enabled');
+};
+
+browser
+  .chain
+  .session()
+  .open('/')
+  .waitForPageToLoad(8000)
+  .click('css=.js-browserid-link')
+  .logIntoBrowserID(config.email, config.password)
+  .selectWindow('title=Open Badge Backpack')
+  .waitForElementPresent('css=div.upload')
+  .end(function(err) {
+    if (err)
+      throw err;
+    console.log("Smoke test successful.");
+  });


### PR DESCRIPTION
...Requires the developer to manually install soda and copy local-config.js.sample to local-config.js and fill it with BrowserID credentials. Also requires Selenium Server to be running on its default port.

Currently this doesn't come with documentation, though, so maybe I should've added that before issuing a pull request.
