### PR TITLE
Fixing docs: avoiding access denied to database 'test_openbadges' when r...

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ changes, so you don't have to manually reload it.
 
         CREATE DATABASE openbadges;
         GRANT ALL PRIVILEGES ON openbadges.* TO badgemaker@localhost IDENTIFIED BY 'secret';
-        CREATE DATABASE openbadges_test;
-        GRANT ALL PRIVILEGES ON openbadges_test.* to badgemaker@localhost IDENTIFIED BY 'secret';
+        CREATE DATABASE test_openbadges;
+        GRANT ALL PRIVILEGES ON test_openbadges.* to badgemaker@localhost IDENTIFIED BY 'secret';
 
 2. Copy the `openbadges/lib/environments/local-dist.js` to
    `openbadges/lib/environments/local.js` and edit the configuration to match


### PR DESCRIPTION
...unning tests.

On my dev env './node_modules/.bin/vows -i' looks for 'test_openbadges' intead of 'openbadges_test'.

vows@0.6.2 ./node_modules/vows 
└── eyes@0.1.7
