### PR TITLE
fixes #81; immediately update apt-get in puppet manifests

### DIFF
--- a/.puppet-manifests/nodes.pp
+++ b/.puppet-manifests/nodes.pp
@@ -1,4 +1,7 @@
 node lucid32 {
+  exec { 'apt-get update':
+    command => '/usr/bin/apt-get update'
+  }
   include essentials
   include mysql::server
   include openbadges::db


### PR DESCRIPTION
This fixes my apt-get 404 issue when provisioning a new VM through vagrant. 
