### PR TITLE
Fix group sharing

### DIFF
--- a/views/portfolio-editor.hogan.js
+++ b/views/portfolio-editor.hogan.js
@@ -101,12 +101,12 @@
   </div>
 
   <script>
-    $('form').on('submit', function(e){
+    $('form.portfolio').on('submit', function(e){
       e.preventDefault();
       return false;
     });
     $('input.save').on('click', function(e){
-      $('form')[0].submit();
+      $('form.portfolio')[0].submit();
     })
   </script>
 </form>


### PR DESCRIPTION
Tabzilla broke group sharing by introducing another form onto the page. This fixes it.
