### PR TITLE
migration helper to convert existing openbadges databases to utf8

### DIFF
--- a/bin/db_to_utf8.js
+++ b/bin/db_to_utf8.js
@@ -1,0 +1,37 @@
+var client = require('../lib/mysql').client;
+var conf = require('../lib/configuration').get('database');
+
+var ENCODING = 'utf8';
+
+var statements = [];
+statements.push("ALTER DATABASE `" + conf.database + "` CHARACTER SET " + ENCODING + ";"); 
+var tables = ['user', 'badge', 'group', 'portfolio'];
+tables.forEach(function (table) {
+  statements.push("ALTER TABLE `" + table + "` CONVERT TO CHARACTER SET " + ENCODING + ";");
+});
+   
+runEach(statements, function(){ process.exit(0); });
+
+function runEach(statements, done) {
+  var i = 0;
+
+  function run(index) {
+    return function(err){
+      if(err) {
+        throw err;
+      }
+      if(index < statements.length) {
+        var statement = statements[index];
+        console.log(statement);
+        client.query(statement, run(index+1));
+      }
+      else {
+        done();
+      }
+    };
+  }
+  
+  run(0)();
+}
+
+  


### PR DESCRIPTION
I think this is all that's needed to convert existing DBs over to utf8. 

All the wacky solutions were for utf8 data stored in a latin1 column, but in our case I think all the incoming utf8 data was actually converted to latin1. The downside is that anything outside of the latin1 character set would have been immediately lost in that conversion; the upside is that converting to utf8 is straightforward.
