### PR TITLE
[fixes #145] Don't show recipient on portfolio edit page.

### DIFF
--- a/views/portfolio-editor.hogan.js
+++ b/views/portfolio-editor.hogan.js
@@ -38,7 +38,7 @@
             </tr>
             <tr>
               <td class='fieldlabel issuer-name'>URL</td>
-              <td><a href={{badge.issuer.origin}}'>{{badge.issuer.origin}}</a></td>
+              <td><a href="{{badge.issuer.origin}}">{{badge.issuer.origin}}</a></td>
             </tr>
             {{#badge.issuer.org}}
             <tr>
@@ -63,17 +63,13 @@
               <td><a href='{{badge.criteria}}'>{{badge.criteria}}</a></td>
             </tr>
 
-            <tr>
-              <td class='section-head' colspan='2'>Issuance Details</td>
-            </tr>
-            <tr>
-              <td class='fieldlabel recipient'>Recipient</td>
-              <td>{{recipient}}</td>
-            </tr>
+            {{#evidence}}
             <tr>
               <td class='fieldlabel evidence'>Evidence</td>
               <td><a href='{{evidence}}'>{{evidence}}</a></td>
             </tr>
+            {{/evidence}}
+            
             {{#issued_on}}
             <tr>
               <td class='fieldlabel'>Issued</td>


### PR DESCRIPTION
Fact: this should probably be fixed with a partial. That dumb `<table>` of information is used in three places and it's fully repeated in all three places.
