### PR TITLE
close button now immediately closes and reports DENIED correctly

### DIFF
--- a/static/js/issuer-frame.js
+++ b/static/js/issuer-frame.js
@@ -338,6 +338,12 @@ function issue(assertions, cb) {
     $("button, a").unbind();
     cb(errors, successes);
   }
+  
+  // setup key handler so we exit immediately if the user hits escape
+  $('body').keydown(function (event) {
+    if (event.keyCode === 27) exit();
+  });
+  
   window.Assertions = {
     processNext: function() {
       if (assertions.length == 0) {

--- a/static/js/issuer-parts/issuer-core.js
+++ b/static/js/issuer-parts/issuer-core.js
@@ -77,6 +77,10 @@ var OpenBadges = (function() {
     //   https://github.com/mozilla/openbadges/wiki/Issuer-API
     // The final (undocumented) argument is used for testing.
     issue: function OpenBadges_issue(assertions, callback, hook) {
+      // setup no-op functions if the user doesn't pass in callback or hook
+      hook = hook || function () {};
+      callback = callback || function () {};
+      
       var root = this.ROOT = findRoot();
       var div = $('<div></div>');
       div.css({
@@ -98,7 +102,6 @@ var OpenBadges = (function() {
       };
       $(iframe).css($.extend(baseStyles, layout.bestSize()));
       $(window).resize(function(){layout.resize(iframe);});
-      if (!hook) hook = function() {};
       $(iframe).one("load", function() {
         hook("load", iframe);
         var channel = Channel.build({
@@ -117,6 +120,9 @@ var OpenBadges = (function() {
             });
           }
         });
+        // set focus to the new iframe so key event handlers work
+        // without the user having to click into it.
+        $(iframe).focus();
       }).appendTo(div);
       hook("create", iframe);
     }


### PR DESCRIPTION
This would close issue #150.

It seemed to me that the close button should immediately close the issuer frame, not just take you to the final report. If I'm hitting the X, I want out.

In order to correctly report badges as DENIED, they can't be popped until the very last moment or clicking close from the accept screen will not report the badge being displayed.
