### PR TITLE
Allow strings & arrays for first param of `issue` API .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 *.rpm
 *.tar.gz
+*.pid
 
 /docs
 /node_modules

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,13 @@ srpm:
 test: npm
 	npm test
 
+start-issuer:
+	node fakeissuer/issuer.js > issuer.pid&
+
+stop-issuer:
+	kill `cat issuer.pid`
+
 jenkins_build: 
 	echo 'yep'
+
+.PHONY: fakeissuer

--- a/fakeissuer/issuer.js
+++ b/fakeissuer/issuer.js
@@ -61,7 +61,5 @@ app.get('/invalid.json', function (request, response) {
   });
 });
 
-
-
-console.log('starting fake issuer');
+console.log(process.pid);
 app.listen(8889);

--- a/fakeissuer/static/index.html
+++ b/fakeissuer/static/index.html
@@ -23,16 +23,19 @@
       }
       
       unhashed.addEventListener('click', function(){
-        OpenBadges.issue(['http://localhost:8889/raw.json?email=' + encodeURIComponent(getEmail())]);
+        var url = 'http://localhost:8889/raw.json?email=' + encodeURIComponent(getEmail());
+        OpenBadges.issue(url);
       },false)
     
       hashed.addEventListener('click', function(){
-        OpenBadges.issue(['http://localhost:8889/hashed.json?email=' + encodeURIComponent(getEmail())]);
+        var url = 'http://localhost:8889/hashed.json?email=' + encodeURIComponent(getEmail())
+        OpenBadges.issue([url]);
       },false)
 
       // added to test whether proper error message is thrown for invalid assertion 
       invalid.addEventListener('click', function(){
-        OpenBadges.issue(['http://localhost:8889/invalid.json?email=' + encodeURIComponent(getEmail())]);
+        var url = 'http://localhost:8889/invalid.json?email=' + encodeURIComponent(getEmail());
+        OpenBadges.issue(url);
       },false)
     
     </script>

--- a/static/js/issuer-parts/issuer-core.js
+++ b/static/js/issuer-parts/issuer-core.js
@@ -77,7 +77,9 @@ var OpenBadges = (function() {
     //   https://github.com/mozilla/openbadges/wiki/Issuer-API
     // The final (undocumented) argument is used for testing.
     issue: function OpenBadges_issue(assertions, callback, hook) {
-      // setup no-op functions if the user doesn't pass in callback or hook
+      // Setup defaults for arguments. I long for the day when javascript
+      // supports defining these in the signature.
+      assertions = typeof assertions === 'string' ? [assertions] : assertions;
       hook = hook || function () {};
       callback = callback || function () {};
 


### PR DESCRIPTION
Addresses issue #167. When a string was being passed in before, it would not immediately fail and instead see it as an array with `"string".length` members which is dumb and wrong. Instead of making it error, I Just made it more lenient so that the first argument can be a string or an array.

To test the change, I modified `fakeissuer` to pass in a string in one case and an array in another. This is not ideal -- we should have some sort of automated, and importantly headless, way of testing `OpenBadges.issue`.

@stenington, @cmcavoy, or @toolness check it out when you get a chance!
