### PR TITLE
Fixed broken start-server.sh

### DIFF
--- a/.puppet-manifests/files/start-server.sh
+++ b/.puppet-manifests/files/start-server.sh
@@ -1,1 +1,1 @@
-cd /home/vagrant/openbadges && /usr/bin/up -w -p 8888 /home/vagrant/openbadges/app.js                                                      
+cd /home/vagrant/openbadges && $NVM_BIN/up -w -p 8888 /home/vagrant/openbadges/app.js


### PR DESCRIPTION
Tried `make test` with nvm-based puppet build, but not `start-server`. 

`up` now lives in $NVM_BIN. Since `start-server` isn't run anywhere in the build and nvm gets sourced in `.bashrc` I think it's safe to just use that environment variable without checking for it and sourcing explicitly. 
