### PR TITLE
Add onlyif check to puppet nvm build

### DIFF
--- a/.puppet-manifests/nvm.pp
+++ b/.puppet-manifests/nvm.pp
@@ -24,5 +24,6 @@ class nvm ($node_version) {
 
   exec { "source-nvm":
     command => "echo 'source /home/vagrant/nvm/nvm.sh' >> /home/vagrant/.bashrc",
+    onlyif => "grep -q 'source /home/vagrant/nvm/nvm.sh' /home/vagrant/.bashrc; test $? -eq 1",
   }
 }


### PR DESCRIPTION
I noticed that puppet was putting redundant lines in `.bashrc`, and I said "NO, PUPPET. NO. DON'T DO THAT."

<img src="http://etc.usf.edu/clipart/45400/45427/45427_scolding_sm.gif"/>
