### PR TITLE
Prevent display of recipient hashes in badge details

### DIFF
--- a/controllers/backpack.js
+++ b/controllers/backpack.js
@@ -171,6 +171,8 @@ exports.manage = function manage(request, response, next) {
 
       if (criteria[0] === '/') body.badge.criteria = origin + criteria;
       if (evidence && evidence[0] === '/') body.evidence = origin + evidence;
+      // Nobody wants to see the hash in the UI, apparently. 
+      if (body.recipient.match(/\w+(\d+)?\$.+/)) body.recipient = user.get('email');
 
       badgeIndex[badge.get('id')] = badge;
       badge.serializedAttributes = JSON.stringify(badge.attributes);


### PR DESCRIPTION
This would close the reopened #147.

Instead of showing hashed recipient emails in the badge details screen, this subs in the email of the logged in user. It won't work if/when we support multiple emails under one account, but that's LATER!

<img src="http://www.blingcheese.com/graphics/greetings/goodbye/later.gif"/>
