### PR TITLE
Issuer frame refactor follow-up

### DIFF
--- a/static/js/issuer-frame/issuer-frame.js
+++ b/static/js/issuer-frame/issuer-frame.js
@@ -87,8 +87,8 @@ var Session = function Session(spec) {
  */
 var Badge = function Badge(assertionUrl, spec) {
   var spec = spec || {};
-  var build = spec.build || function() { return {}; };
-  var issue = spec.issue || function() { return {}; };
+  var _build = spec.build || function() { return {}; };
+  var _issue = spec.issue || function() { return {}; };
 
   var buildState;
   var issueState;
@@ -115,10 +115,9 @@ var Badge = function Badge(assertionUrl, spec) {
       changeState('complete');
     });
 
-    /* Kicks off building of the badge.
-       TODO: rename to build */
-    this.start = function start() {
-      buildState = build(assertionUrl);
+    /* Kicks off building of the badge. */
+    this.build = function build() {
+      buildState = _build(assertionUrl);
 
       jQuery.when(buildState).then(
         function buildSuccess(data) {
@@ -139,7 +138,7 @@ var Badge = function Badge(assertionUrl, spec) {
 	      throw new Error('Cannot issue unbuilt badge');
 
       changeState('pendingIssue');
-      issueState = issue.call(this, assertionUrl);
+      issueState = _issue.call(this, assertionUrl);
 
       jQuery.when(issueState).then(
         function issueSuccess() {
@@ -282,7 +281,7 @@ var App = function App(assertionUrls, spec) {
       }
       else {
         badges.forEach(function(badge, i, arr) {
-          badge.start();
+          badge.build();
 	      });
       }
     },

--- a/static/test/issuer-frame/component-tests.js
+++ b/static/test/issuer-frame/component-tests.js
@@ -101,7 +101,7 @@ asyncTest('Issuing a single badge', function(){
     equal(this.assertionUrl, 'foo');
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Badge fails build', function(){
@@ -123,7 +123,7 @@ asyncTest('Badge fails build', function(){
     deepEqual(this.error, {url: 'foo', reason: 'asplode'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Badge fails issue', function(){
@@ -148,7 +148,7 @@ asyncTest('Badge fails issue', function(){
     deepEqual(this.error, {url: 'foo', reason: 'asplode'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Badge rejected by user', function(){
@@ -167,7 +167,7 @@ asyncTest('Badge rejected by user', function(){
     deepEqual(this.error, {url: 'foo', reason: 'DENIED'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Rejection reason and data', function(){
@@ -182,7 +182,7 @@ asyncTest('Rejection reason and data', function(){
     deepEqual(this.error, {url: 'foo', reason: 'asplode', other: 'data', goes: 'here'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Successful badge state transitions', function(){
@@ -213,7 +213,7 @@ asyncTest('Successful badge state transitions', function(){
     deepEqual(states, ['pendingBuild', 'built', 'pendingIssue', 'issued']);
     start();
   });
-  b.start();
+  b.build();
   build.resolve();
 });
 
@@ -231,7 +231,7 @@ asyncTest('Badge built and issued events', function(){
     deepEqual(events, ['built', 'issued'], 'saw both');
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('badge.result() for issued', function(){
@@ -239,7 +239,7 @@ asyncTest('badge.result() for issued', function(){
   b.on('built', function(){
     b.issue();
   });
-  b.start();
+  b.build();
   b.always(function(){
     equal(this.result(), 'foo');
     start();
@@ -250,7 +250,7 @@ asyncTest('badge.result() for failed', function(){
   var b = Badge('foo', {
     build: function(){ return $.Deferred().reject('asplode', {more: 'stuff'}); }
   });
-  b.start();
+  b.build();
   b.always(function(){
     deepEqual(this.result(), {url: 'foo', reason: 'asplode'});
     start();
@@ -266,7 +266,7 @@ asyncTest('Building badge data', function(){
     deepEqual(b.data, {url: 'foo', extra: 'stuff'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Building badge data with deferred', function(){
@@ -284,7 +284,7 @@ asyncTest('Building badge data with deferred', function(){
     deepEqual(b.data, {url: 'foo', extra: 'stuff'}, 'badgeData holds build');
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Building badge data and failing', function(){
@@ -298,7 +298,7 @@ asyncTest('Building badge data and failing', function(){
     deepEqual(b.data, {badge: 'data'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 asyncTest('Rejecting without badge data does not clobber', function(){
@@ -318,7 +318,7 @@ asyncTest('Rejecting without badge data does not clobber', function(){
     deepEqual(b.error, {url: 'foo', reason: 'reason'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 test('Checking badge state', function(){
@@ -340,7 +340,7 @@ asyncTest('Failing a failed badge does nothing', function(){
     deepEqual(b.result(), {url: 'foo', reason: 'first'});
     start();
   });
-  b.start();
+  b.build();
 });
 
 


### PR DESCRIPTION
One of the nit-fixes introduced a naming collision in Badge. This fixes it, and takes care of a renaming TODO that would have run in to the same collision issue as well.
