### PR TITLE
added popover information for badges in the backpack

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -588,3 +588,15 @@ table.information {
 body {
   cursor: default;
 }
+
+
+/**
+  badge "popinfo" multi block styling (description span + issuer span)
+**/
+.popover-content p span {
+  display: block;
+}
+
+.popover-content p span + span {
+  margin-top: 1em;
+}

--- a/views/backpack.hogan.js
+++ b/views/backpack.hogan.js
@@ -24,7 +24,7 @@
     <h1><span data-title="Badges" data-content="These are the badges you've earned so far! Click on one to see its details." rel="popover">Badges{{#tooltips}}<i class="icon-info-sign"></i>{{/tooltips}}</span></h1>
     <div id="badges" class="js-badges">
       {{#badges}}
-        <span draggable="true" class="openbadge" data-id="{{attributes.id}}">
+        <span draggable="true" class="openbadge" data-id="{{attributes.id}}" rel="popinfo" data-title="{{attributes.body.badge.name}}" data-content="<span>{{attributes.body.badge.description}}</span><span>Issuer: {{attributes.body.badge.issuer.name}}</span>">
           <img src="{{attributes.image_path}}" width="64px"/>
         </span>
       {{/badges}}
@@ -63,7 +63,7 @@
         </span>
           
           {{#attributes.badgeObjects}}
-            <span draggable="true" class="openbadge" data-id="{{attributes.id}}">
+            <span draggable="true" class="openbadge" data-id="{{attributes.id}}" rel="popinfo" data-title="{{attributes.body.badge.name}}" data-content="<span>{{attributes.body.badge.description}}</span><span>Issuer: {{attributes.body.badge.issuer.name}}</span>">
               <img src="{{attributes.image_path}}" width="64px"/>
             </span>
           {{/attributes.badgeObjects}}
@@ -88,9 +88,12 @@
   {{/badges}}
 </script>
 
-{{#tooltips}}
 <script>
   $(function(){
+    $('[rel="popinfo"]').popover({
+      animation: false
+    });
+{{#tooltips}}
     $('[rel="popover"]').popover({
       animation: false,
       placement: 'right'
@@ -98,9 +101,9 @@
     $('[rel="tooltip"]').tooltip({
       animation: false
     });
+{{/tooltips}}
   });
 </script>
-{{/tooltips}}
 
 {{=|| ||=}} <!-- need to change delimeter so hogan doesn't parse these --->
 
@@ -223,7 +226,7 @@
 </script>
 
 <script type='text/html' class='partial' id='badgeTpl'>
-  <span draggable="true" class="openbadge">
+  <span draggable="true" class="openbadge" data-id="{{attributes.id}}" rel="popinfo" data-title="{{attributes.body.badge.name}}" data-content="<span>{{attributes.body.badge.description}}</span><span>Issuer: {{attributes.body.badge.issuer.name}}</span>">
     <img src="{{image_path}}" width="64px"/>
   </span>
 </script>


### PR DESCRIPTION
would be nicer if this could be done through a partial (there's three instances of the same code) but until then, this will do. Styling is not 100% according to mockup, due to the arrow being a clever border-hack.
