### PR TITLE
Refix #86

### DIFF
--- a/static/js/issuer-frame/main.js
+++ b/static/js/issuer-frame/main.js
@@ -97,7 +97,8 @@ function issue(assertions, cb){
       var badge = badges[next++];
       var templateArgs = {
         assertion: badge.data.badge,
-        user: Session.currentUser
+        user: Session.currentUser,
+        unhashedRecipient: badge.data.recipient
       };
       $("#badge-ask").fadeOut(function(){
         $(this).empty()

--- a/views/issuer-frame.hogan.js
+++ b/views/issuer-frame.hogan.js
@@ -95,7 +95,7 @@
       <div class="span4 columns badge-details">
         <dl>
           <dt>Recipient</dt>
-	        <dd>[[ assertion.recipient ]]</dd>
+	        <dd>[[ unhashedRecipient ]]</dd>
 
           <dt>Name</dt>
           <dd>[[ assertion.badge.name ]]</dd>


### PR DESCRIPTION
I think the refactor reintroduced an old bug in which the hashed recipient was shown in the issuer frame. This fixes it.

It was a UI bug, so testing would involve Selenium or something. Frustrating, but I'm punting on that.
