### PR TITLE
Ux changes 281

### DIFF
--- a/views/backpack.hogan.js
+++ b/views/backpack.hogan.js
@@ -22,16 +22,19 @@
   </div>
   
   <div class="span4 column groups">
+    {{#groups.length}}
     <section>
       <header>
         <div class="title">Groups</div>
       </header>
       
       <ul>
-        <li>Placeholder</li>
-        <li>Another Placeholder</li>
+        {{#groups}}
+        <li class="group" data-id="{{group.id}}"><a href="share/{{attributes.url}}/">{{attributes.name}}</a></li>
+        {{/groups}}
       </ul>
     </section>
+    {{/groups.length}}
 
     <section>
       <header>
@@ -128,5 +131,13 @@
 
   .groups ul {
     margin-top: 1em;
+    list-style: none;
+    margin-left: 0;
+  }
+  
+  .groups .group a {
+    color: black;
+    text-decoration: underline;
+    font-weight: bold;
   }
 </style>


### PR DESCRIPTION
styling for groups (plain black text links)

<img src="http://i.imgur.com/3UMDG.png">

note that this has embedded CSS and JavaScript. We can either land first, and then relocate when we're happy with the new templating solution, or do it the other way around. Given the low number of files touched, landing, then fixing, is probably nicer.
