### PR TITLE
Ux changes 282

### DIFF
--- a/views/backpack.hogan.js
+++ b/views/backpack.hogan.js
@@ -149,6 +149,14 @@
     font-weight: bold;
   }
 
+  .groups .group.new {
+    border: 1px solid black;
+    background: white;
+    color: black;
+    border-radius: 15px;
+    padding: 5px;
+  }
+
   .pages {
     text-align: right;
     line-height: 1em;
@@ -356,8 +364,9 @@
   function init() {
     document.removeEventListener("DOMContentLoaded", init, false);
 
+
     function loadTemplate() {
-      var newGroup = $("<li>Pretended to load the new group 'template'." +
+      var newGroup = $("<li class='group new'>Pretended to load the new group 'template'." +
                         "<span class='editable'><br>" +
                         "<button class='btn save'>save</button> " +
                         "<button class='btn cancel'>cancel</button> " +
@@ -389,6 +398,7 @@
 
       $(".save", template).click(function() {
         $(".editable", template).remove();
+        $(template).removeClass("new");
         enableButton();
       });
 


### PR DESCRIPTION
Added a create new group button, with save/cancel stubs.

button:

<img src="http://i.imgur.com/qt0SP.png">

when pressed:

<img src="http://i.imgur.com/Ms44P.png">

save will commit the group (removing the "new" class), cancel will remove the list item from the listing again. These obviously still need actual javascript behaviour tied to them, and a partial to live somewhere =)

note that this has embedded CSS and JavaScript. We can either land first, and then relocate when we're happy with the new templating solution, or do it the other way around. Given the low number of files touched, landing, then fixing, is probably nicer.
