### PR TITLE
Fix share page information table

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -405,6 +405,8 @@ form.baker #assertion {
 }
 
 table.information {
+  table-layout: fixed;
+  word-wrap: break-word;
   margin-bottom: 0;
   padding: 10px 3px;
   border-collapse: separate;
@@ -416,8 +418,11 @@ table.information {
   padding: 2px 12px;
 }
 
+.information .fieldLabelCol {
+  width: 120px;
+}
+
 .information td.fieldlabel {
-  padding-left: 50px;
   white-space: nowrap;
   font-weight: bold;
   text-align: right;
@@ -445,10 +450,13 @@ table.information {
   vertical-align: middle;
 }
 
+.information .imageCol {
+  width: 148px;
+}
 .information img {
   max-height: 128px;
   max-width: 128px;
-  margin: auto 10px; 
+  margin: auto; 
 }
 
 .information button {

--- a/views/portfolio.hogan.js
+++ b/views/portfolio.hogan.js
@@ -32,73 +32,79 @@
     {{#badges}}
       {{#attributes}}
         <li>
-          {{#body}}
+        {{#body}}
           <h3>{{badge.name}}</h3>
 
           <p class='story'>{{_userStory}}</p>
 
           <table class='information'>
-            <tr>
-              <td rowspan="100" class='image'>
-                <img src="{{image_path}}">
-              </td>
+            <colgroup>
+              <col class="imageCol">
+              <col class="fieldLabelCol">
+              <col class="dataCol">
+            </colgroup>
+            <tbody>
+              <tr>
+                <td rowspan="100" class='image'>
+                  <img src="{{image_path}}">
+                </td>
 
-              <td class='section-head' colspan='2'>Issuer Details</td>
-            </tr>
-            <tr>
-              <td class='fieldlabel issuer-name'>Name</td>
-              <td>{{badge.issuer.name}}</td>
-            </tr>
-            <tr>
-              <td class='fieldlabel issuer-name'>URL</td>
-              <td><a href="{{badge.issuer.origin}}">{{badge.issuer.origin}}</a></td>
-            </tr>
-            {{#badge.issuer.org}}
-            <tr>
-              <td class='fieldlabel issuer-name'>Organization</td>
-              <td>{{badge.issuer.org}}</td>
-            </tr>
-            {{/badge.issuer.org}}
+                <td class='section-head' colspan='2'>Issuer Details</td>
+              </tr>
+              <tr>
+                <td class='fieldlabel issuer-name'>Name</td>
+                <td>{{badge.issuer.name}}</td>
+              </tr>
+              <tr>
+                <td class='fieldlabel issuer-name'>URL</td>
+                <td><a href="{{badge.issuer.origin}}">{{badge.issuer.origin}}</a></td>
+              </tr>
+              {{#badge.issuer.org}}
+              <tr>
+                <td class='fieldlabel issuer-name'>Organization</td>
+                <td>{{badge.issuer.org}}</td>
+              </tr>
+              {{/badge.issuer.org}}
 
-            <tr>
-              <td class='section-head' colspan='2'>Badge Details</td>
-            </tr>
-            <tr>
-              <td class='fieldlabel'>Name</td>
-              <td>{{badge.name}}</td>
-            </tr>
-            <tr>
-              <td class='fieldlabel'>Description</td>
-              <td>{{badge.description}}</td>
-            </tr>
-            <tr>
-              <td class='fieldlabel'>Criteria</td>
-              <td><a href='{{badge.criteria}}'>{{badge.criteria}}</a></td>
-            </tr>
+              <tr>
+                <td class='section-head' colspan='2'>Badge Details</td>
+              </tr>
+              <tr>
+                <td class='fieldlabel'>Name</td>
+                <td>{{badge.name}}</td>
+              </tr>
+              <tr>
+                <td class='fieldlabel'>Description</td>
+                <td>{{badge.description}}</td>
+              </tr>
+              <tr>
+                <td class='fieldlabel'>Criteria</td>
+                <td><a href='{{badge.criteria}}'>{{badge.criteria}}</a></td>
+              </tr>
 
-            {{#evidence}}
-            <tr>
-              <td class='fieldlabel evidence'>Evidence</td>
-              <td><a href='{{evidence}}'>{{evidence}}</a></td>
-            </tr>
-            {{/evidence}}
+              {{#evidence}}
+              <tr>
+                <td class='fieldlabel evidence'>Evidence</td>
+                <td><a href='{{evidence}}'>{{evidence}}</a></td>
+              </tr>
+              {{/evidence}}
 
-            {{#issued_on}}
-            <tr>
-              <td class='fieldlabel'>Issued</td>
-              <td>{{issued_on}}</td>
-            </tr>
-            {{/issued_on}}
+              {{#issued_on}}
+              <tr>
+                <td class='fieldlabel'>Issued</td>
+                <td>{{issued_on}}</td>
+              </tr>
+              {{/issued_on}}
 
-            {{#expires}}
-            <tr>
-              <td class='fieldlabel'>Expiration</td>
-              <td>{{expires}}</td>
-            </tr>
-            {{/expires}}
-
-            {{/body}}
+              {{#expires}}
+              <tr>
+                <td class='fieldlabel'>Expiration</td>
+                <td>{{expires}}</td>
+              </tr>
+              {{/expires}}
+            </tbody>
           </table>
+        {{/body}}
         </li>
       {{/attributes}}
     {{/badges}}


### PR DESCRIPTION
Changes the share page badge info tables to fixed layout so they won't grow huge and pop down below the story box, leaving a huge blank area if the person hasn't written a story for a badge. This _will_ awkwardly break long urls or other solid text, but that can't be avoided.

Closes #375.
