### PR TITLE
Show disown button on badge page

### DIFF
--- a/less/backpack.less
+++ b/less/backpack.less
@@ -1,6 +1,10 @@
 @badgeSize: 110px;
+
 @sectionSpacing: 16px;
 @elementSpacing: 8px;
+
+@separator: 1px solid #999;
+
 
 .badgeImg {
   width: @badgeSize;
@@ -27,7 +31,7 @@
     table {
       width: 100%;
       margin-bottom: @elementSpacing;
-      border-bottom: 1px solid #999;
+      border-bottom: @separator;
 
       tr {
         th {
@@ -35,13 +39,13 @@
           font-size: 1.2em;
           text-align: left;
         }
-        /* label cells */
         td:first-child {
+          /* label cells */
           padding-right: @sectionSpacing;
           font-weight: bold;
         }
-        /* data cells */
         td:last-child {
+          /* data cells */
           width: 100%; /* shrinks label cells to contents */
         }
       }
@@ -68,9 +72,12 @@ textarea.panel {
   padding: 0.5em;
 }
 
+/* Bootstrap tweaks/fixes */
+
 textarea[class*="span"] {
   resize: vertical;
 }
+
 
 /* Header classes
  * Right now a bunch of header styling comes from Bootstrap,
@@ -79,10 +86,15 @@ textarea[class*="span"] {
 
 h2 { margin-bottom: @elementSpacing; }
 
+
 /* Margin classes
  * Use these in your html to set spacing as appropriate,
  * if it doesn't make sense to apply the margins to a
  * more semantically named element.
  */
+
 .st { margin-top: @sectionSpacing; }
 .sb { margin-bottom: @sectionSpacing; }
+
+.et { margin-top: @elementSpacing; }
+.eb { margin-bottom: @elementSpacing; }

--- a/views/badge-details.html
+++ b/views/badge-details.html
@@ -1,6 +1,8 @@
 {% extends "layout.html" %}
 {% block body %}
 <div class="row">
+
+  <!-- left column -->
   <div class="span8 column">
 
     <div class="badgeInfo">
@@ -37,17 +39,28 @@
     </div>
 
     <div class="row st">
+
       <div class="span4">
         <h2>Badge Notes</h2>
         <textarea class="panel span4" rows="6"
           placeholder="Enter your own notes for this badge"></textarea>
         <button class="btn">Save Notes</button>
       </div>
+
+      <div class="span4 et">
+        <button class="btn">Disown This Badge</button>
+        <a href="#">What is this?</a>
+      </div>
     </div>
+
   </div>
-  
+  <!-- end left column -->
+
+  <!-- right column -->
   <div class="span4 column">
     Right.
   </div>
+  <!-- end right column -->
+
 </div>
 {% endblock %}


### PR DESCRIPTION
:warning: :exclamation: :turtle: This pull includes #385, which includes #383, so deal with those first.

This just shows the button and link. There's no vertical separator like in the wireframe because that's a real pain to do well.

Also, no "What is this?" tooltip functionality is included because I don't have copy, so I'll spawn another issue for that.
