### PR TITLE
Add header to legal pages

### DIFF
--- a/static/css/legal.css
+++ b/static/css/legal.css
@@ -1,8 +1,6 @@
-body {
-  padding: 20px 0;
-}
 
-.container {
+body > .container {
+  padding-top: 2em;
   padding-bottom: 4em;
 }
 

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -1,11 +1,23 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet" />
     <link rel="stylesheet" href="/css/bootstrap-2.0.2.min.css" />
     <link rel="stylesheet" href="/css/style.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/css/legal.css" type="text/css" media="all" />
   </head>
   <body>
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="container" style="position: relative;">
+          <h3><a class="brand" href="/">Open Badge Backpack</a></h3>
+          <a href="http://www.mozilla.org/" id="tabzilla">a mozilla.org joint</a>
+          <ul class="nav">
+            <li><a href="/">Home</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
     <div class="container">
       <h1>Privacy & Mozilla Badge Backpack</h1>
       <p>
@@ -180,5 +192,6 @@ Sometimes, we change our privacy policies. When we do, we may notify you on the 
       </div>
 
     </div>
+    <script src="//www.mozilla.org/tabzilla/media/js/tabzilla.js"></script>
   </body>
 </html>

--- a/static/tou.html
+++ b/static/tou.html
@@ -1,11 +1,23 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet" />
     <link rel="stylesheet" href="/css/bootstrap-2.0.2.min.css" />
     <link rel="stylesheet" href="/css/style.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/css/legal.css" type="text/css" media="all" />
   </head>
   <body>
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="container" style="position: relative;">
+          <h3><a class="brand" href="/">Open Badge Backpack</a></h3>
+          <a href="http://www.mozilla.org/" id="tabzilla">a mozilla.org joint</a>
+          <ul class="nav">
+            <li><a href="/">Home</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
     <div class="container">
       <h1>Mozilla Badge Backpack Terms of Use</h1>
       <h3>April 4, 2012</h3>
@@ -214,6 +226,8 @@
         You may not assign your rights or delegate its obligations under these Terms.  These Terms are not intended to benefit, nor shall it be deemed to give rise to, any rights in any third party.  These Terms will be governed and construed in accordance with the laws of California, without regard to conflict of law principles. The parties are independent contractors.  These Terms shall not be construed to create a joint venture or partnership between the parties.  Neither party shall be deemed to be an employee, agent, partner or legal representative of the other for any purpose and neither shall have any right, power or authority to create any obligation or responsibility on behalf of the other. These Terms constitute the entire agreement between the parties with respect to the subject matter hereof.  These Terms supersede, and govern, any other prior or collateral agreements with respect to the subject matter hereof. If any provision of these Terms are held or made invalid or unenforceable for any reason, such invalidity shall not affect the remainder of these Terms, and the invalid or unenforceable provisions shall be replaced by a mutually acceptable provision, which being valid, legal and enforceable comes closest to the original intentions of the parties hereto and has like economic effect.  The failure of either party at any time or times to require performance of any provision hereof shall in no manner affect the right at a later time to enforce the same.  No waiver by either party of the breach of any term or covenant contained in these Terms, whether by conduct or otherwise, in any one or more instances, shall be deemed to be, or construed as, a further or continuing waiver of any such breach or a waiver of the breach of any other term or covenant contained in these Terms. 
       </p>
     </div>
+
+    <script src="//www.mozilla.org/tabzilla/media/js/tabzilla.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Adds header with home link and tabzilla (no help or user/logout) to legal pages.

Closes #126.
