### PR TITLE
Fix homeless popovers

### DIFF
--- a/static/js/backpack.js
+++ b/static/js/backpack.js
@@ -446,8 +446,18 @@ Badge.View = Backbone.View.extend({
     this.detailsView = new Details.View({ model: this.model });
     this.detailsView.render();
     this.setElement($(el));
+    $(el).popover({
+      animation:false,
+      trigger: 'hover',
+      html: true
+    });
     return this;
   },
+
+  remove: function () {
+    this.$el.popover('hide');
+    Backbone.View.prototype.remove.call(this);
+  }
 });
 
 Badge.View.all = [];

--- a/views/backpack.html
+++ b/views/backpack.html
@@ -90,14 +90,9 @@
   {% endfor %}
 </script>
 
+{% if tooltips %}
 <script>
   $(function(){
-    $('[rel="popinfo"]').popover({
-      animation: false,
-      trigger: 'hover',
-      html: true
-    });
-{% if tooltips %}
     $('[rel="popover"]').popover({
       animation: false,
       placement: 'right',
@@ -106,7 +101,7 @@
     $('[rel="tooltip"]').tooltip({
       animation: false
     });
-{% endif %}
   });
 </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Move creation of popovers into backpack.js, and add cleanup when badge view is removed.

Closes #454.
