### PR TITLE
fix #470: Quick and dirty unix timestamp date formatting

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,14 @@ app.locals({
 var env = new nunjucks.Environment(new nunjucks.FileSystemLoader('views'));
 env.express(app);
 
+env.addFilter('formatdate', function (rawDate) {
+  if (parseInt(rawDate, 10) == rawDate) {
+    var date = new Date(rawDate * 1000);
+    return date.toString();
+  }
+  return rawDate;
+});
+
 // Middleware. Also see `middleware.js`
 // ------------------------------------
 app.use(express.static(path.join(__dirname, "static")));

--- a/static/js/backpack.js
+++ b/static/js/backpack.js
@@ -12,6 +12,13 @@ $.ajaxSetup({
 })
 if(!nunjucks.env) {
     nunjucks.env = new nunjucks.Environment(new nunjucks.HttpLoader('/views'));
+    nunjucks.env.addFilter('formatdate', function (rawDate) {
+      if (parseInt(rawDate, 10) == rawDate) {
+        var date = new Date(rawDate * 1000);
+        return date.toString();
+      }
+      return rawDate;
+    });
 }
 }(/*end setup*/)
 

--- a/views/badge-data.html
+++ b/views/badge-data.html
@@ -56,14 +56,14 @@
     {% if badge.attributes.body.issued_on %}
     <tr>
       <td class='fieldlabel'>Issued</td>
-      <td>{{badge.attributes.body.issued_on}}</td>
+      <td>{{badge.attributes.body.issued_on|formatdate}}</td>
     </tr>
     {% endif %}
 
     {% if badge.attributes.body.expires %}
     <tr>
       <td class='fieldlabel'>Expiration</td>
-      <td>{{badge.attributes.body.expires}}</td>
+      <td>{{badge.attributes.body.expires|formatdate}}</td>
     </tr>
     {% endif %}
   </tbody>


### PR DESCRIPTION
Here's a quick tweak to check for unix timestamps, and to display them as human readable. Haven't quite gotten my head around the tests, so maybe this PR is more for illustration than merge
