### PR TITLE
Stub methods in backpack controller

### DIFF
--- a/controllers/backpack.js
+++ b/controllers/backpack.js
@@ -300,3 +300,15 @@ exports.userBadgeUpload = function userBadgeUpload(request, response) {
     });
   });
 };
+
+/**
+ * Stub methods to prevent crash in Express 3.0.5
+ */
+
+exports.details = function details (request, response) {
+  return;
+}
+
+exports.deleteBadge = function deleteBadge (request, response) {
+  return;
+}


### PR DESCRIPTION
I was setting this up locally and had an issue after installing dependencies and running the app:

```
Error: Router#get() requires all callbacks to be functions
    at Router.route.Route.sensitive (/Users/luke/Repos/openbadges/node_modules/express/lib/router/index.js:249:11)
    at Array.forEach (native)
    at Router.route (/Users/luke/Repos/openbadges/node_modules/express/lib/router/index.js:247:13)
    at Function.methods.forEach.app.(anonymous function) [as get] (/Users/luke/Repos/openbadges/node_modules/express/lib/application.js:408:24)
    at Object.<anonymous> (/Users/luke/Repos/openbadges/app.js:107:5)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
```

In express 3.0.5, routes without proper functions will throw an error: [visionmedia/express/#1446](https://github.com/visionmedia/express/pull/1446), so this was happening because the backpack controller wasn't exporting methods for `details` and `deleteBadge`.

This adds in stub methods these in the backpack controller and prevents the error, allowing the app to run normally. This should also get your travis-ci badge green again.

```
$ node app.js
info: environment: development
info: opening server on port: 8888
info: READY PLAYER ONE
```
