### PR TITLE
Closes #478.

### DIFF
--- a/controllers/backpack.js
+++ b/controllers/backpack.js
@@ -135,7 +135,7 @@ exports.stats = function stats(request, response, next) {
       var issuer = issuers[name];
       return { name: name, total: issuer.total, url: issuer.url }
     });
-    totalPerIssuer.sort(function(issuer1,issuer2){
+    totalPerIssuer.sort(function(issuer1, issuer2) {
       return issuer2.total - issuer1.total
     });
     return {


### PR DESCRIPTION
 Added sort functionality on stats page: https://beta.openbadges.org/stats. Issuers with most badges are displayed on top now. totalPerIssuer object is sorted before sending over to view now.

Edited files:
openbadges/controllers/backpack.js
