### PR TITLE
closes #485 Fixed issue where newly created groups cannot be destroyed.

### DIFF
--- a/static/js/backpack.js
+++ b/static/js/backpack.js
@@ -422,6 +422,12 @@ Badge.View = Backbone.View.extend({
       var newBadgeCollection = new Badge.Collection([])
       var newGroupModel = new Group.Model({badges: newBadgeCollection})
       var newGroupView = new Group.View({model: newGroupModel});
+
+      // Add model to the list of all the groups and retain a reference
+      var allGroups = groupView.model.collection;
+      allGroups.add(newGroupView.model);
+      newGroupView.model.collection = allGroups;
+
       newBadgeCollection.belongsTo = newGroupModel;
       newGroupView.render();
 


### PR DESCRIPTION
Groups that are loaded initially retains a reference to a list of all the groups. However, groups created on the fly do not. Fixed by adding new group to master list and retaining a reference.
