### PR TITLE
Adding VPAT page for Backpack 508 compliance

### DIFF
--- a/static/css/vpat.css
+++ b/static/css/vpat.css
@@ -1,0 +1,56 @@
+body > .container {
+  padding-top: 2em;
+  padding-bottom: 4em;
+}
+
+dl {
+  overflow: hidden;
+}
+dt {
+  float: left;
+  clear: left;
+}
+dd {
+  float: left;
+}
+
+table {
+  border: 1px solid #eee;
+  background: #fff;
+  text-align: left;
+  margin: 24px 0;
+}
+caption {
+  background: #eee;
+  font-weight: bold;
+  text-align: left;
+}
+tr:nth-child(2n) {
+  background: #fafafa;
+}
+th {
+  font-weight: normal;
+}
+caption, 
+th, 
+td {
+  border: 1px solid #eee;
+  padding: 4px 12px;
+}
+th,
+td {
+  vertical-align: top;
+}
+.c1 {
+  width: 45%;
+}
+.c2 {
+  width: 0;
+}
+.c3 {
+  width: 20%;
+}
+.c4 {
+  width: 35%;
+}
+

--- a/static/vpat.html
+++ b/static/vpat.html
@@ -1,0 +1,482 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Voluntary Product Accessibility Template</title>
+    <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/bootstrap-2.0.2.min.css" />
+    <link rel="stylesheet" href="/css/style.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="/css/vpat.css" type="text/css" media="all" />
+  </head>
+  <body>
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="container" style="position: relative;">
+          <h3><a class="brand" href="/">Open Badge Backpack</a></h3>
+          <a href="http://www.mozilla.org/" id="tabzilla">a mozilla.org joint</a>
+          <ul class="nav">
+            <li><a href="/">Home</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="container">
+      <h1>Section 508 Compliance (VPAT)</h1>
+      <dl>
+        <dt>Date:</dt>
+        <dd>February 12, 2013</dd>
+        <dt>Name of Product:</dt>
+        <dd>The Mozilla Open Badges Backpack</dd>
+        <dt>Point of Contact:</dt>
+        <dd></dd>
+      </dl>
+      <table>
+      <caption>Summary Table</caption>
+      <tbody>
+        <tr>
+          <th class="c1" scope="col">Criteria</th>
+          <th class="c2"></th>
+          <th class="c3" scope="col">Supporting Features</th>
+          <th class="c4" scope="col">Remarks and explanations</th>
+        </tr>
+        <tr>
+          <td>Section 1194.21 Software Applications and Operating Systems</td>
+          <td></td>
+          <td>Applicable</td>
+          <td>Supports with exceptions</td>
+        </tr>
+        <tr>
+          <td>Section 1194.22 Web-based Internet Information and Applications</td>
+          <td></td>
+          <td>Applicable</td>
+          <td>Supports with exceptions</td>
+        </tr>
+        <tr>
+          <td>Section 1194.23 Telecommunications Products</td>
+          <td></td>
+          <td>Not Applicable</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>Section 1194.24 Video and Multi-media Products</td>
+          <td></td>
+          <td>Not Applicable</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>Section 1194.25 Self-Contained, Closed Products</td>
+          <td></td>
+          <td>Not Applicable</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>Section 1194.26 Desktop and Portable Computers</td>
+          <td></td>
+          <td>Not Applicable</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>Section 1194.31 Functional Performance Criteria</td>
+          <td></td>
+          <td>Applicable</td>
+          <td>Supports with exceptions</td>
+        </tr>
+        <tr>
+          <td>Section 1194.41 Information, Documentation and Support</td>
+          <td></td>
+          <td>Applicable</td>
+          <td>Supports with exceptions</td>
+        </tr>
+      </tbody>
+      </table>
+
+      <table>
+      <caption>Section 1194.21 Software Applications and Operating Systems</caption>
+      <tbody>
+        <tr>
+          <th class="c1" scope="col">Criteria</th>
+          <th class="c2"></th>
+          <th class="c3" scope="col">Supporting Features</th>
+          <th class="c4" scope="col">Remarks and explanations</th>
+        </tr>
+        <tr>
+          <td>(a) When software is designed to run on a
+          system that has a keyboard, product functions shall be executable
+          from a keyboard where the function itself or the result of
+          performing a function can be discerned textually.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>Some functionality, such as grouping
+          badges, relies on drag-and-drop without a keyboard accessible
+          alternative.</td>
+        </tr>
+        <tr>
+          <td>(b) Applications shall not disrupt or
+          disable activated features of other products that are identified as
+          accessibility features, where those features are developed and
+          documented according to industry standards. Applications also shall
+          not disrupt or disable activated features of any operating system
+          that are identified as accessibility features where the application
+          programming interface for those accessibility features has been
+          documented by the manufacturer of the operating system and is
+          available to the product developer.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(c) A well-defined on-screen indication of
+          the current focus shall be provided that moves among interactive
+          interface elements as the input focus changes. The focus shall be
+          programmatically exposed so that Assistive Technology can track
+          focus and focus changes.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>A visual indication of focus is provided
+          on interactive elements. The usage of modal windows can sometimes
+          occlude focused elements.</td>
+        </tr>
+        <tr>
+          <td>(d) Sufficient information about a user
+          interface element including the identity, operation and state of
+          the element shall be available to Assistive Technology. When an
+          image represents a program element, the information conveyed by the
+          image must also be available in text.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>The Backpack does not fully utilize
+          WAI-ARIA to expose role and state information.</td>
+        </tr>
+        <tr>
+          <td>(e) When bitmap images are used to
+          identify controls, status indicators, or other programmatic
+          elements, the meaning assigned to those images shall be consistent
+          throughout an application's performance.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(f) Textual information shall be provided
+          through operating system functions for displaying text. The minimum
+          information that shall be made available is text content, text
+          input caret location, and text attributes.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(g) Applications shall not override user
+          selected contrast and color selections and other individual display
+          attributes.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(h) When animation is displayed, the
+          information shall be displayable in at least one non-animated
+          presentation mode at the option of the user.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(i) Color coding shall not be used as the
+          only means of conveying information, indicating an action,
+          prompting a response, or distinguishing a visual element.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(j) When a product permits a user to
+          adjust color and contrast settings, a variety of color selections
+          capable of producing a range of contrast levels shall be
+          provided.</td>
+          <td></td>
+          <td>Not applicable</td>
+          <td>The Backpack does not provide color or contrast settings.</td>
+        </tr>
+        <tr>
+          <td>(k) Software shall not use flashing or
+          blinking text, objects, or other elements having a flash or blink
+          frequency greater than 2 Hz and lower than 55 Hz.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(l) When electronic forms are used, the
+          form shall allow people using Assistive Technology to access the
+          information, field elements, and functionality required for
+          completion and submission of the form, including all directions and
+          cues.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>Not all form controls have accessible
+          names.</td>
+        </tr>
+      </tbody>
+      </table>
+
+      <table>
+      <caption>Section 1194.22 Web-based Intranet and Internet information and Applications</caption>
+      <tbody>
+        <tr>
+          <th class="c1" scope="col">Criteria</th>
+          <th class="c2"></th>
+          <th class="c3" scope="col">Supporting Features</th>
+          <th class="c4" scope="col">Remarks and explanations</th>
+        </tr>
+        <tr>
+          <td>(a) A text equivalent for every non-text
+          element shall be provided (e.g., via "alt", "longdesc", or in
+          element content).</td>
+          <td></td>
+          <td>Not supported</td>
+          <td>Text equivalents are not currently
+          provided for all non-text elements.</td>
+        </tr>
+        <tr>
+          <td>(b) Equivalent alternatives for any
+          multimedia presentation shall be synchronized with the
+          presentation.</td>
+          <td></td>
+          <td>Not applicable</td>
+          <td>The Backpack does not include any multimedia presentations.</td>
+        </tr>
+        <tr>
+          <td>(c) Web pages shall be designed so that
+          all information conveyed with color is also available without
+          color, for example from context or markup.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(d) Documents shall be organized so they
+          are readable without requiring an associated style sheet.</td>
+          <td></td>
+          <td>Not supported</td>
+          <td>The Backpack relies heavily on the use of
+          its associated stylesheets.</td>
+        </tr>
+        <tr>
+          <td>(e) Redundant text links shall be provided
+          for each active region of a server-side image map.</td>
+          <td></td>
+          <td>Not applicable</td>
+          <td>No image maps are used.</td>
+        </tr>
+        <tr>
+          <td>(f) Client-side image maps shall be
+          provided instead of server-side image maps except where the regions
+          cannot be defined with an available geometric shape.</td>
+          <td></td>
+          <td>Not applicable</td>
+          <td>No image maps are used.</td>
+        </tr>
+        <tr>
+          <td>(g) Row and column headers shall be
+          identified for data tables.</td>
+          <td></td>
+          <td>Not supported</td>
+          <td>Row and column headers are not properly
+          identified in data tables.</td>
+        </tr>
+        <tr>
+          <td>(h) Markup shall be used to associate data
+          cells and header cells for data tables that have two or more
+          logical levels of row or column headers.</td>
+          <td></td>
+          <td>Not applicable</td>
+          <td>The Backpack has no data tables with two or more logical levels of headers.</td>
+        </tr>
+        <tr>
+          <td>(i) Frames shall be titled with text that
+          facilitates frame identification and navigation</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>Frames used for technical reasons are not
+          titled.</td>
+        </tr>
+        <tr>
+          <td>(j) Pages shall be designed to avoid
+          causing the screen to flicker with a frequency greater than 2 Hz
+          and lower than 55 Hz.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(k) A text-only page, with equivalent
+          information or functionality, shall be provided to make a web site
+          comply with the provisions of this part, when compliance cannot be
+          accomplished in any other way. The content of the text-only page
+          shall be updated whenever the primary page changes.</td>
+          <td></td>
+          <td>Not Applicable</td>
+          <td>Accessibility provisions can be provided in the Backpack without
+          the use of a separate text-only page.</td>
+        </tr>
+        <tr>
+          <td>(l) When pages utilize scripting languages
+          to display content, or to create interface elements, the
+          information provided by the script shall be identified with
+          functional text that can be read by Assistive Technology.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>(m) When a web page requires that an
+          applet, plug-in or other application be present on the client
+          system to interpret page content, the page must provide a link to a
+          plug-in or applet that complies with 1194.21(a) through (l).</td>
+          <td></td>
+          <td>Not applicable</td>
+          <td>No applets, plug-ins or other applications are required.</td>
+        </tr>
+        <tr>
+          <td>(n) When electronic forms are designed to
+          be completed on-line, the form shall allow people using Assistive
+          Technology to access the information, field elements, and
+          functionality required for completion and submission of the form,
+          including all directions and cues.</td>
+          <td></td>
+          <td>Supports with exceptions.</td>
+          <td>Not all form controls have accessible
+          names.</td>
+        </tr>
+        <tr>
+          <td>(o) A method shall be provided that
+          permits users to skip repetitive navigation links.</td>
+          <td></td>
+          <td>Not supported</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(p) When a timed response is required, the
+          user shall be alerted and given sufficient time to indicate more
+          time is required.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+      </tbody>
+      </table>
+
+      <table>
+      <caption>Section 1194.31 Functional Performance Criteria</caption>
+      <tbody>
+        <tr>
+          <th class="c1" scope="col">Criteria</th>
+          <th class="c2"></th>
+          <th class="c3" scope="col">Supporting Features</th>
+          <th class="c4" scope="col">Remarks and explanations</th>
+        </tr>
+        <tr>
+          <td>(a) At least one mode of operation and
+          information retrieval that does not require user vision shall be
+          provided, or support for Assistive Technology used by people who
+          are blind or visually impaired shall be provided.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>Some functionality, such as grouping
+          badges, relies on drag-and-drop without a keyboard accessible
+          alternative.</td>
+        </tr>
+        <tr>
+          <td>(b) At least one mode of operation and
+          information retrieval that does not require visual acuity greater
+          than 20/70 shall be provided in audio and enlarged print output
+          working together or independently, or support for Assistive
+          Technology used by people who are visually impaired shall be
+          provided.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>The Backpack supports the use of screen magnifiers.</td>
+        </tr>
+        <tr>
+          <td>(c) At least one mode of operation and
+          information retrieval that does not require user hearing shall be
+          provided, or support for Assistive Technology used by people who
+          are deaf or hard of hearing shall be provided</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(d) Where audio information is important
+          for the use of a product, at least one mode of operation and
+          information retrieval shall be provided in an enhanced auditory
+          fashion, or support for assistive hearing devices shall be
+          provided.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(e) At least one mode of operation and
+          information retrieval that does not require user speech shall be
+          provided, or support for Assistive Technology used by people with
+          disabilities shall be provided.</td>
+          <td></td>
+          <td>Supports</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>(f) At least one mode of operation and
+          information retrieval that does not require fine motor control or
+          simultaneous actions and that is operable with limited reach and
+          strength shall be provided.</td>
+          <td></td>
+          <td>Supports with exceptions</td>
+          <td>Where drag-and-drop is required, drop
+          targets are large.</td>
+        </tr>
+      </tbody>
+      </table>
+
+      <table>
+      <caption>Section 1194.41 Information, Documentation and Support</caption>
+      <tbody>
+        <tr>
+          <th class="c1" scope="col">Criteria</th>
+          <th class="c2"></th>
+          <th class="c3" scope="col">Supporting Features</th>
+          <th class="c4" scope="col">Remarks and explanations</th>
+        </tr>
+        <tr>
+          <td>(a) Product support documentation provided
+          to end-users shall be made available in alternate formats upon
+          request, at no additional charge</td>
+          <td></td>
+          <td>Supports</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>(b) End-users shall have access to a
+          description of the accessibility and compatibility features of
+          products in alternate formats or alternate methods upon request, at
+          no additional charge.</td>
+          <td></td>
+          <td>Supports</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>(c) Support services for products shall
+          accommodate the communication needs of end-users with
+          disabilities.</td>
+          <td></td>
+          <td>Supports</td>
+          <td></td>
+        </tr>
+      </tbody>
+      </table>
+    </div>
+
+    <script src="//www.mozilla.org/tabzilla/media/js/tabzilla.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Visible at `/vpat.html`.

There are a few blanks that still need to be filled in on the page, but that will be easier to do when this is up somewhere for people to see it.

This is a big part of #477, but doesn't fully close it.
