### PR TITLE
Adding database migration to start-server script

### DIFF
--- a/.puppet-manifests/files/start-server.sh
+++ b/.puppet-manifests/files/start-server.sh
@@ -1,1 +1,1 @@
-cd /home/vagrant/openbadges && $NVM_BIN/up -n 1 -w -p 8888 /home/vagrant/openbadges/app.js
+cd /home/vagrant/openbadges && /home/vagrant/openbadges/bin/db-migrate up && $NVM_BIN/up -n 1 -w -p 8888 /home/vagrant/openbadges/app.js


### PR DESCRIPTION
@toolness `start-server` is an alternative to `make start` used in the VM. I'm adding the `db-migrate up` command there too.
