### PR TITLE
Adds the ability to turn on a development test user

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,8 +49,9 @@ app.use(middleware.logRequests());
 app.use(middleware.cookieSessions());
 app.use(middleware.userFromSession());
 app.configure('development', function () {
-  if (app.config.get('enable_test_user'))
-    app.use(middleware.testUser());
+  var testUser = process.env['OPENBADGES_TEST_USER'];
+  if (testUser)
+    app.use(middleware.testUser(testUser));
 });
 app.use(flash());
 app.use(middleware.csrf({

--- a/lib/environments/local-dist.js
+++ b/lib/environments/local-dist.js
@@ -38,9 +38,5 @@ exports.config = {
     protocol: 'https',
     server: 'verifier.login.persona.org',
     path: '/verify'
-  },
-
-  // Enables a default test user in development environments
-  // Useful when persona might not be reachable
-  enable_test_user: false
+  }
 }

--- a/middleware.js
+++ b/middleware.js
@@ -77,9 +77,7 @@ exports.userFromSession = function userFromSession() {
   };
 };
 
-exports.testUser = function testUser() {
-  const username = 'someone@something.org';
-
+exports.testUser = function testUser(username) {
   return function(req, res, next) {
     if (!req.user) {
       User.findOrCreate(username, function (err, user) {


### PR DESCRIPTION
This is nice while, say, on an Amtrak train with unreliable internets and Persona just won't load.

When turned on, this will jam user `someone@something.org` into the session if you're not otherwise logged in. It's turned on through a `lib/environments/local.js` setting.
