### PR TITLE
Fix: ballertime badge public_paths collided across users

### DIFF
--- a/controllers/demo.js
+++ b/controllers/demo.js
@@ -53,7 +53,7 @@ exports.massAward = function (req, res) {
       awardBadge({
         assertion: item.assertion,
         url: item.assertionUrl,
-        public_path: email + item.baseName,
+        public_path: [email, item.baseName].join(':'),
         imagedata: item.imgData,
         recipient: email
       }, function(err) {


### PR DESCRIPTION
Ballertime was silently failing for me. It looks like the `public_path` collided across users, so `/demo/ballertime` was a once-per-database thing, and failed silently. This makes it work across users, and fail vocally.
