### PR TITLE
Remove `home` link from header

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -40,7 +40,6 @@
           </a></h3>
           <a href="http://www.mozilla.org/" id="tabzilla">a mozilla.org joint</a>
           <ul class="nav">
-            <li><a href="/">Home</a></li>
             {% if user %}
               <li><a href="/backpack/settings">Settings</a></li>
             {% endif %}


### PR DESCRIPTION
Subpart of #565: Remove home link from header. It's redundant.
