### PR TITLE
database migration for Facebook long-lived user access tokens

### DIFF
--- a/migrations/20130228161816-add-fb-access-token-column.js
+++ b/migrations/20130228161816-add-fb-access-token-column.js
@@ -3,15 +3,11 @@ var async = require('async');
 var type = dbm.dataType;
 
 exports.up = function(db, callback) {
-  async.series([
-    db.runSql.bind(db, 'ALTER TABLE `user` ' +
-                       'ADD fb_access_token VARCHAR(255) DEFAULT NULL')
-  ], callback);
+  db.runSql('ALTER TABLE `user` ' +
+            'ADD fb_access_token VARCHAR(255) DEFAULT NULL', callback);
 };
 
 exports.down = function(db, callback) {
-  async.series([
-    db.runSql.bind(db, 'ALTER TABLE `user` ' +
-                       'DROP COLUMN fb_access_token;')
-  ], callback);
+  db.runSql('ALTER TABLE `user` ' +
+            'DROP COLUMN fb_access_token', callback);
 };


### PR DESCRIPTION
In order to autopush opengraph objects to Facebook (issue #548), [extended access tokens](https://developers.facebook.com/docs/howtos/login/extending-tokens/) (which can be stored and are valid for 60 days) allow users to push opengraph objects even if they're not logged into FB at the time they upload a badge to their backpack.

Extends the users model to store these tokens.

<!---
@huboard:{"order":103.9375}
-->
