### PR TITLE
add Facebook library for display integration

### DIFF
--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -124,7 +124,12 @@ exports.checkApplicationAccess = function (accessToken, appId, callback) {
 		  return callback(errorMsg, null);
 	  } else {
 		  try {
-		    return callback(null, body);
+        resp = JSON.parse(body);
+        if ((resp.data[0].installed == 1) && (resp.data[0].publish_actions == 1)) {
+          return callback(null, true);
+        } else {
+          throw 'Incorrect Facebook permissions for the application to publish and access information.';
+        }
       } catch(err) {
         return callback(errorMsg, null);
       }


### PR DESCRIPTION
I initially used Facebook's Javascript SDK to publish badges for #547, but found that more-advanced calls like extending a user access token (where an app's secret key must be passed) aren't supported. There are a few node libraries out there, but they focus on specific APIs Facebook offers and are incomplete. For lack of a better option, I have a custom script to potentially add to the /lib folder to handle the following:
1. publish opengraph objects
2. check permissions of an application
3. extend client-side User Access Tokens

<!---
@huboard:{"order":103.875}
-->
