### PR TITLE
Renamed buttons in grant permission flow

### DIFF
--- a/views/backpack-connect.html
+++ b/views/backpack-connect.html
@@ -21,8 +21,7 @@
   <input name="_csrf" type="hidden" value="{{ csrfToken }}">
   <input name="callback" type="hidden" value="{{ callback }}">
   <input name="scope" type="hidden" value="{{ joinedScope }}">
-  <button class="btn btn-primary" type="submit">Grant permission
-    to {{ clientDomain }}.</button>
+  <button class="btn btn-primary" type="submit">Grant permission</button>
   <a class="btn" href="{{ denyCallback }}">Deny permission</a>
   <a class="btn" href="/backpack/signout">I am not 
     {{ user.attributes.email }}.</a>


### PR DESCRIPTION
As per @emgolie comment: https://github.com/mozilla/openbadges/issues/693#issuecomment-14520235 that is part of #693 I changed the buttons to say "Grant permission" and "Deny permission".

cc/ @toolness can you review and merge this? gracias! :ear: 
