### PR TITLE
Hide 'connected accounts' on settings and 'share' button on badge view.

### DIFF
--- a/views/badge-data.html
+++ b/views/badge-data.html
@@ -10,10 +10,14 @@
         <img src="{{badge.attributes.image_path}}">
         {% if disownable %}
         <button class='btn btn-danger disown'>Remove this Badge</button>
+        <!-- TODO: Re-enable this when sharing actually works well.
+
         <form action="/share/badge/{{ badge.attributes.id }}" method="post">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
           <input class="btn" type="submit" value="Share">
         </form>
+
+        -->
         {% endif %}
       </td>
 

--- a/views/settings.html
+++ b/views/settings.html
@@ -5,6 +5,8 @@
 <form method="post" class="settings">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
+  <!-- TODO: Re-enable this when sharing actually works well.
+
   <fieldset id="accounts">
     <legend>Connected Accounts</legend>
     <div class="item">
@@ -42,6 +44,8 @@
       {% endif %}
     </div>
   </fieldset>
+
+  -->
   <fieldset id="issuer-acceptance">
     <legend>Connected Issuers</legend>
     {% if issuers.length %}


### PR DESCRIPTION
This is only temporary, we'll re-enable things within the next week.

This fixes #731.
