### PR TITLE
Optimize less middleware for dev and prod

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ var configuration = require('./lib/configuration');
 var flash = require('connect-flash');
 var nunjucks = require('nunjucks');
 var less = require('less-middleware');
+var _ = require('underscore');
 
 var app = express();
 app.logger = logger;
@@ -45,12 +46,23 @@ env.addFilter('formatdate', function (rawDate) {
 
 // Middleware. Also see `middleware.js`
 // ------------------------------------
-app.use(less({
+var lessConfig = {
   src: path.join(__dirname, "static/less"),
   paths: [path.join(__dirname, "static/vendor/bootstrap/less")],
   dest: path.join(__dirname, "static/css"),
   prefix: '/css'
-}));
+};
+app.configure('development', function() {
+  app.use(less(_.extend(lessConfig, {
+    force: true
+  })));
+});
+app.configure('production', function() {
+  app.use(less(_.extend(lessConfig, {
+    once: true,
+    compress: true
+  })));
+});
 app.use(express.static(path.join(__dirname, "static")));
 app.use(express.static(path.join(configuration.get('var_dir'), "badges")));
 app.use("/views", express.static(path.join(__dirname, "views")));


### PR DESCRIPTION
Force recompilation in development, minimize and only do a single compilation check in production.

See [middleware docs](https://github.com/emberfeather/less.js-middleware#options) for explanation/more potential options.
