### PR TITLE
less middleware fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,6 @@ var logger = require('./lib/logging').logger;
 var configuration = require('./lib/configuration');
 var flash = require('connect-flash');
 var nunjucks = require('nunjucks');
-var less = require('less-middleware');
 var _ = require('underscore');
 
 var app = express();
@@ -41,23 +40,7 @@ env.addFilter('formatdate', function (rawDate) {
 
 // Middleware. Also see `middleware.js`
 // ------------------------------------
-var lessConfig = {
-  src: path.join(__dirname, "static/less"),
-  paths: [path.join(__dirname, "static/vendor/bootstrap/less")],
-  dest: path.join(__dirname, "static/css"),
-  prefix: '/css'
-};
-app.configure('development', function() {
-  app.use(less(_.extend(lessConfig, {
-    force: true
-  })));
-});
-app.configure('production', function() {
-  app.use(less(_.extend(lessConfig, {
-    once: true,
-    compress: true
-  })));
-});
+app.use(middleware.less(app.get('env')));
 app.use(express.static(path.join(__dirname, "static")));
 app.use(express.static(path.join(configuration.get('var_dir'), "badges")));
 app.use("/views", express.static(path.join(__dirname, "views")));

--- a/middleware.js
+++ b/middleware.js
@@ -4,6 +4,8 @@ var configuration = require('./lib/configuration');
 var logger = require('./lib/logging').logger;
 var crypto = require('crypto');
 var User = require('./models/user');
+var path = require('path');
+var lessMiddleware = require('less-middleware');
 
 // `COOKIE_SECRET` is randomly generated on the first run of the server,
 // then stored to a file and looked up on restart to maintain state.
@@ -157,7 +159,25 @@ exports.notFound = function notFound() {
       res.type('txt').send('Not found');
     }
   }
-}
+};
+
+exports.less = function less(env) {
+  var config = {
+    src: path.join(__dirname, "static/less"),
+    paths: [path.join(__dirname, "static/vendor/bootstrap/less")],
+    dest: path.join(__dirname, "static/css"),
+    prefix: '/css',
+    /* default to production settings */
+    once: true,
+    compress: true
+  };
+  if ('development' === env) {
+    config.once = false;
+    config.compress = "auto";
+    config.force = true;
+  }
+  return lessMiddleware(config);
+};
 
 var utils = exports.utils = {};
 var pseudoRandomBytes = function(num) {


### PR DESCRIPTION
This pushes the less middleware config into `middleware.js` and changes the logic slightly. Previously less middleware would only get set up for _development_ and _production_ environments, meaning that it wouldn't work on staging. Now it's set up with production defaults, but overridden with development settings if the NODE_ENV === development. This way staging and production should share the same settings.
