### PR TITLE
Add (some) frontend tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "nock": "~0.15.2",
     "prompt": "~0.2.9",
     "jws": "0.2.2",
-    "tap": "~0.3.2"
+    "tap": "~0.3.2",
+    "cheerio": "0.10.8"
   },
   "dependencies": {
     "connect-flash": "0.1.0",

--- a/test/page-utils.js
+++ b/test/page-utils.js
@@ -1,0 +1,33 @@
+const cheerio = require('cheerio');
+const server = require('../app');
+const Badge = require('../models/badge');
+
+/* Sort of mimic response.render, but grabs app.render from 
+   the http.Server object. 
+   Seems dumb, but I don't know how else to do it.
+*/
+exports.render = function render(view, options, fn) {
+  var app = server._events.request;
+
+  if ('function' == typeof options) {
+    fn = options, options = {};
+  }
+
+  options._locals = app.locals;
+
+  app.render(view, options, function(err, html) {
+    var $ = cheerio.load(html);
+    fn(err, $);
+  });
+};
+
+exports.badgeList = function badgeList(length) {
+  var list = [];
+  while(length--) {
+    list.push(new Badge());
+  }
+  return list;
+};
+
+exports.noBadgesPattern = /time to start earning/;
+

--- a/test/page.all-badges.test.js
+++ b/test/page.all-badges.test.js
@@ -1,0 +1,22 @@
+const test = require('tap').test;
+const utils = require('./page-utils');
+
+test('allBadges.html', function(t) {
+
+  t.test('with 0 badges', function(t) {
+    utils.render('allBadges.html', {badges: []}, function(err, $) {
+      t.notOk(err, 'no error');
+      t.ok($('body').html().match(utils.noBadgesPattern), 'no badge message displayed');
+      t.end();
+    });
+  });
+
+  t.test('with 2 badges', function(t) {
+    utils.render('allBadges.html', { badges: utils.badgeList(2) }, function(err, $) {
+      t.notOk(err, 'no error');
+      t.same($('.openbadge').length, 2, 'renders 2 badges');
+      t.end();
+    });
+  });
+
+});

--- a/test/page.recent-badges.test.js
+++ b/test/page.recent-badges.test.js
@@ -1,0 +1,22 @@
+const test = require('tap').test;
+const utils = require('./page-utils');
+
+test('recentBadges.html', function(t) {
+
+  t.test('with 0 badges', function(t) {
+    utils.render('recentBadges.html', {badges: []}, function(err, $) {
+      t.notOk(err, 'no error');
+      t.ok($('body').html().match(utils.noBadgesPattern), 'no badge message displayed');
+      t.end();
+    });
+  });
+
+  t.test('with 2 badges', function(t) {
+    utils.render('recentBadges.html', { badges: utils.badgeList(2) }, function(err, $) {
+      t.notOk(err, 'no error');
+      t.same($('.openbadge').length, 2, 'renders 2 badges');
+      t.end();
+    });
+  });
+
+});


### PR DESCRIPTION
This adds a page-utils test lib, and two page tests that demonstrate how we could write more tests for frontend page rendering using [cheerio](https://github.com/MatthewMueller/cheerio).
