### PR TITLE
Fixed #831 by fixing a typo in the test configuration.

### DIFF
--- a/test/app-utils.js
+++ b/test/app-utils.js
@@ -124,7 +124,7 @@ function replaceModuleFunctionsForTesting(port) {
   var conf = require('../lib/configuration');
   var testConf = {
     protocol: 'http:',
-    host: 'localhost',
+    hostname: 'localhost',
     port: port
   };
   var originalVerify = browserid.verify;


### PR DESCRIPTION
When I encountered #831, it was because I had changed my `hostname` setting in  `lib/environments/local.js` from `localhost` to a VMWare intranet IP so I could  test the backpack from an IE8 VM. The test configuration was overriding the `host` setting instead of the `hostname` setting, which was the wrong one to override--hence the app harness was still going back to the current config when resolving absolute URLs, instead of the test one.
