### PR TITLE
staticTemplateViews middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ app.use(middleware.less(app.get('env')));
 app.use(express.static(path.join(__dirname, "static")));
 app.use(express.static(path.join(configuration.get('var_dir'), "badges")));
 app.use("/views", express.static(path.join(__dirname, "views")));
-app.use(middleware.staticTemplateViews(env));
+app.use(middleware.staticTemplateViews(env, 'static/'));
 app.use(middleware.noFrame({ whitelist: [ '/issuer/frame.*', '/', '/share/.*' ] }));
 app.use(express.bodyParser());
 app.use(express.cookieParser());

--- a/middleware.js
+++ b/middleware.js
@@ -173,7 +173,9 @@ exports.less = function less(env) {
   return lessMiddleware(_.defaults(base, config));
 };
 
-exports.staticTemplateViews = function staticTemplateViews(env) {
+exports.staticTemplateViews = function staticTemplateViews(env, viewPrefix) {
+  viewPrefix = viewPrefix || '';
+
   function hasView(env, view) {
     try { 
       env.getTemplate(view);
@@ -189,7 +191,7 @@ exports.staticTemplateViews = function staticTemplateViews(env) {
   return function (req, res, next) {
     var match;
     if(match = /^\/([a-zA-Z0-9\/]+\.html)$/.exec(req.path)) {
-      var view = match[1];
+      var view = viewPrefix + match[1];
       if (hasView(env, view)) {
         return res.render(view, function(err, html) {
           if (err) return next(err);

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -198,6 +198,32 @@ test('middleware#staticTemplateViews', function(t) {
       t.end();
     });
   });
+
+  t.test('limit the view search path', function (t) {
+    var env = new nunjucks.Environment({
+      getSource: function(name) { 
+        return {
+          src: 'TEMPLATE',
+          path: name,
+          upToDate: function() { return true; }
+        };
+      }
+    });
+
+    const handler = middleware.staticTemplateViews(env, 'static/');
+
+    conmock({
+      handler: handler,
+      request: {
+        path: '/tou.html'
+      }
+    }, function(err, mock) {
+      t.same(mock.fntype, 'render', 'render called');
+      t.same(mock.path, 'static/tou.html', 'with view');
+      t.end();
+    });
+  
+  });
 });
 
 // necessary because middleware requires mysql, which opens a client


### PR DESCRIPTION
Sorry to lose the original commentary in #812, but this pares down the pull request which I think makes it easier to discuss.

This introduces a new piece of middleware that lets static pages like tou.html, privacy.html, and vpat.html extend a layout so they won't get out of sync with style changes so easily. It doesn't convert those pages over to use it yet.
