### PR TITLE
Fix var_dir -> var_path typo in app.js.

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,6 @@ env.addFilter('formatdate', function (rawDate) {
 // ------------------------------------
 app.use(middleware.less(app.get('env')));
 app.use(express.static(path.join(__dirname, "static")));
-app.use(express.static(path.join(configuration.get('var_path'), "badges")));
 app.use("/views", express.static(path.join(__dirname, "views")));
 app.use(middleware.staticTemplateViews(env, 'static/'));
 app.use(middleware.noFrame({ whitelist: [ '/issuer/frame.*', '/', '/share/.*' ] }));


### PR DESCRIPTION
The typo actually crashes the app when running node v0.10.5, which makes `path.join()` check its arguments and ensure that they're all strings.
