### PR TITLE
Make bake errors not kill server

### DIFF
--- a/controllers/baker.js
+++ b/controllers/baker.js
@@ -47,10 +47,18 @@ exports.baker = function (req, res) {
     function bakeBadge(info, callback) {
       const image = preferedImage(info.resources);
       awardOptions.assertion = info.structures.assertion;
-      bakery.bake({
-        image: image,
-        data: url
-      }, callback)
+      try {
+        bakery.bake({
+          image: image,
+          data: url
+        }, callback)
+      }
+      catch (ex) {
+        callback({
+          error: 'Unable to bake',
+          reason:ex.toString()
+        });
+      }
     },
     function maybeAward(imageData, callback) {
       const shouldAward = query.award && query.award !== 'false';


### PR DESCRIPTION
Stops badge baking errors from taking down the server. It's not
clear if the badge png is bad, or it's a problem in a png library,
but this change reports an error instead of killing everything.
