### PR TITLE
Update bakery 0.2.2 -> 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "winston": "~0.5.10",
     "optimist": "~0.3.0",
     "openbadges-validator": "0.0.21",
-    "openbadges-bakery": "0.2.2",
+    "openbadges-bakery": "0.2.5",
     "newrelic": "~0.9.19",
     "async": "~0.2.6"
   },


### PR DESCRIPTION
Includes a fix for #877, not sure what `0.2.3` and `0.2.4` have.
