### PR TITLE
Align metadata labels to top left. Resolves GH-778

### DIFF
--- a/static/less/backpack.less
+++ b/static/less/backpack.less
@@ -225,7 +225,8 @@ table.information {
 .information td.fieldlabel {
   white-space: nowrap;
   font-weight: bold;
-  text-align: right;
+  text-align: left;
+  vertical-align: top;
 }
 
 .information td.fieldlabel:after {


### PR DESCRIPTION
Starting with the most trivial ticket I could find to start getting familiar with the codebase. :hamburger: 

![screen shot 2013-07-18 at 9 04 17 pm](https://f.cloud.github.com/assets/747641/823915/55740322-f028-11e2-8878-a6f174b06089.png)
