### PR TITLE
[WIP] Account removal

### DIFF
--- a/bin/db-account
+++ b/bin/db-account
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+var optimist = require('optimist');
+var prompt = require('prompt');
+var util = require('util');
+var User = require('../models/user');
+var db = require('../lib/configuration').get('database').database;
+
+var argv = optimist
+  .usage('Usage: db-account [options] <email>\n\nDescribes (or deletes) a user account')
+  .describe('delete', 'delete the specified account')
+  .alias('d', 'delete')
+  .boolean('delete')
+
+  .describe('color', 'print colorized account data')
+  .alias('c', 'color')
+  .boolean('color')
+
+  .alias('h', 'help')
+  .alias('h', '?')
+  .boolean('h')
+  .argv;
+
+var email = argv._[0];
+var dryRun = true;
+var colorized = !!argv.color;
+
+if (argv.help || !email) {
+  optimist.showHelp();
+  process.exit(1);
+}
+
+if (argv.delete)
+  dryRun = false;
+else
+  prompt.override = {
+    permission: 'Y'
+  };
+
+prompt.start();
+prompt.message = prompt.delimiter = '';
+
+function warning() {
+  var msg = 'This command will '
+    + 'DELETE ALL DATA'.bold.underline
+    + ' associated with `' + email + '`'
+    + ' in `' + db + '`!'
+    + ' Proceed?';
+  return msg.red;
+}
+
+var property = {
+  name: 'permission',
+  message: warning(),
+  validator: /^(y(es)?|no?)$/i,
+  warning: 'Must respond yes or no',
+  default: 'no'
+};
+
+prompt.get(property, function(err, result) {
+  if (err) throw err;
+  if (result.permission.match(/^y/i)) {
+    User.deleteAccount(email, { dryRun: dryRun }, function(err, result) {
+      if (err)
+        console.log('Error:'.red, err);
+      else if (!result)
+        console.log('No account for'.yellow, email);
+      else
+        console.log(colorized ? util.inspect(result, false, 99, true) : result);
+      process.exit(0);
+    });
+  }
+  else {
+    console.log('Aborted'.yellow);
+    process.exit(0);
+  }
+});

--- a/test/user-model.test.js
+++ b/test/user-model.test.js
@@ -85,11 +85,57 @@ testUtils.prepareDatabase({
     })
   })
 
+  test('User.deleteAccount dry run', function (t) {
+    const email = 'deleteme@example.org';
+    User.deleteAccount(email, { dryRun: true }, function(err, account) {
+      t.notOk(err, "should not have an error");
+
+      t.equal(account.user.email, 'deleteme@example.org', "delete the right account");
+      t.equal(account.badges.length, 1, "one badge deleted");
+      t.equal(account.badges[0].id, 1, "has id");
+      t.equal(account.groups.length, 1, "one group deleted");
+      t.equal(account.groups[0].id, 1, "has id");
+      t.equal(account.portfolios[account.groups[0].id].length, 1, "one portfolio deleted");
+      t.equal(account.portfolios[account.groups[0].id][0].id, 1, "has id");
+
+      async.parallel([
+        function(callback) {
+          User.find({ id: 1 }, function(err, users) {
+            t.equal(users.length, 1, 'not deleted');
+            callback();
+          });
+        },
+        function(callback) {
+          Badge.find({ user_id: 1 }, function(err, badges) {
+            t.equal(badges.length, 1, 'not deleted');
+            callback();
+          });
+        },
+        function(callback) {
+          Group.find({ user_id: 1 }, function(err, groups) {
+            t.equal(groups.length, 1, 'not deleted');
+            callback();
+          });
+        }
+      ], function() {
+        t.end();
+      })
+    });
+  });
+
   test('User.deleteAccount for user with badge, group, and portfolio', function (t) {
     const email = 'deleteme@example.org';
-    User.deleteAccount(email, function(err, user) {
+    User.deleteAccount(email, function(err, account) {
       t.notOk(err, "should not have an error");
-      t.equal(user.attributes.email, 'deleteme@example.org', "delete the right account");
+
+      t.equal(account.user.email, 'deleteme@example.org', "delete the right account");
+      t.equal(account.badges.length, 1, "one badge deleted");
+      t.equal(account.badges[0].id, 1, "has id");
+      t.equal(account.groups.length, 1, "one group deleted");
+      t.equal(account.groups[0].id, 1, "has id");
+      t.equal(account.portfolios[account.groups[0].id].length, 1, "one portfolio deleted");
+      t.equal(account.portfolios[account.groups[0].id][0].id, 1, "has id");
+
       async.parallel([
         function(callback) {
           User.find({ id: 1 }, function(err, users) {


### PR DESCRIPTION
Here's a somewhat frightening proposal for dealing with account removal in the backpack. I think I'd be just as happy having it shot down as accepted, but I'm a wimp about these things.

I've added a `User.deleteAccount` method that gathers up a user's badges, groups, and portfolios, and then deletes them all (unless `dryRun` is specified) returning all of that data. Then there's a `bin/db-account` utility that lets you run that from the command line given an email address.

The method itself is kind of awful for a few reasons:
- It finds and deletes entries one by one instead of using `findAndDestroy` because the latter doesn't return the deleted records.
- The code for deleting portfolios in a group, for example, should arguably live in the `Group` model, but I haven't done that. I wasn't even sure this functionality should be made readily available in the `User` object since it's only meant to be run very rarely, by hand, but it was more testable that way.
- It doesn't stream the results, and I'm not sure what the implications are of that for an account with lots of badges or groups or something. 
- It's non-atomic, so we could theoretically end up with half-deleted accounts. 

There are probably other problems too. I'm presenting this as a step up (hopefully) from doing manual database surgery in production instead.

@toolness @andrewhayward @brianloveswords
