### PR TITLE
Quick fix for #907: make issuer modal fully scrollable

### DIFF
--- a/static/less/badge-accept.less
+++ b/static/less/badge-accept.less
@@ -99,6 +99,10 @@ button,
   }
 }
 
+.navbar-fixed-top {
+  position: fixed;
+}
+
 #ajax-loader {
   padding-top: 7px;
   display: none;


### PR DESCRIPTION
This is a quick fix for #907. It makes the issuer API modal fully scrollable. The minor downside is that the scroll bar overlaps with the fixed navbar header which looks weird to me, but I want to get a fix out the door.
