### PR TITLE
Make openbadges Heroku-able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 
 /static/css/*.css
 /static/js/nunjucks-templates.js
+
+.idea

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ./node_modules/.bin/up -n 1 -p $PORT app.js

--- a/lib/environments/local-dist.js
+++ b/lib/environments/local-dist.js
@@ -12,7 +12,7 @@ exports.config = {
   // that the application will try to bind to. When remote_port is *not*
   // set, this will also be used to construct fully qualified urls to
   // application resources
-  port: 8888,
+  port: process.env.PORT || 8888,
 
   // If you are running the application behind a proxy or load
   // balancer, this should be set the externally accessible port.
@@ -34,10 +34,10 @@ exports.config = {
   // Make sure to create a user that has full privileges to the database
   database: {
     driver: 'mysql',
-    host: '127.0.0.1',
-    user: 'badgemaker',
-    password: 'secret',
-    database: 'openbadges'
+    host: process.env.DATABASE_HOST || '127.0.0.1',
+    user: process.env.DATABASE_USER || 'badgemaker',
+    password: process.env.DATABASE_PASS || 'secret',
+    database: process.env.DATABASE_NAME || 'openbadges'
   },
 
   // BrowserID verifier location.


### PR DESCRIPTION
Not sure if you folks care or not, but I deployed openbadges to a Heroku dyno to test something out, and this is what I reconfigured to make it work (primarily I just added in some env vars so they could be setup/used on the Heroku end, and I added a Procfile). I could write up some simple steps for setting up the dyno as well.

May not be of interest to you, but figured i'd share!
