### PR TITLE
Fix `up` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "db-migrate": "0.3.2",
     "nunjucks": "0.1.9",
     "underscore": "~1.3.3",
-    "up-time": "~0.2.2",
+    "up-time": "~0.2.1",
     "optimist": "~0.3.0",
     "openbadges-validator": "0.0.21",
     "openbadges-bakery": "0.2.6",


### PR DESCRIPTION
Fixes #925 

I just found out (because of an error in openbadger) that `up` was unpublished and republished as `up-time` and that something completely different was published at `up`. So this fixes that. Needless to say, I'm _super_ happy that happened and that they did that.

Also, `up-time` has been marked as deprecated so at some point we should just completely remove it as a dependency and figure out something else for code reloading.
