### PR TITLE
Convert images back to base64 before reinserting them.

### DIFF
--- a/models/badge-image.js
+++ b/models/badge-image.js
@@ -46,7 +46,8 @@ BadgeImage.prototype.bakeAndSave = function (globalCallback) {
   }.bind(this)
 
   const saveImage = function saveImage(bakedImageData, callback) {
-    this.set('image_data', bakedImageData)
+    const b64image = Buffer(bakedImageData).toString('base64')
+    this.set('image_data', b64image)
     this.set('baked', true)
     this.save(callback)
   }.bind(this)

--- a/test/badge-image-model.test.js
+++ b/test/badge-image-model.test.js
@@ -45,6 +45,14 @@ $.prepareDatabase({
     badgeimage.bakeAndSave(function (err, image) {
       t.notOk(err, 'no error')
 
+      const isRawPng =
+        image
+          .get('image_data')
+          .toString('utf8')
+          .slice(1, 4) == 'PNG'
+
+      t.notOk(isRawPng, 'should not be a raw PNG')
+
       const bakedData = image.toBuffer()
       t.ok(image.get('baked'), 'image says its baked')
       t.notOk(bakedData == unbakedData, 'not the same')


### PR DESCRIPTION
[fixes #968]

When I wrote the code to bake images as they came out of the database, I forgot to re-encode them as base64 before putting them back into the database.

I wrote an automated test, but I also did some manual testing by doing some database surgery:
1. Hit `demo/ballertime`
2. Get base64 for an unbaked badge (on OS X, `base64 < static/_demo/zero.large.png | pbcopy`)
3. Replace one of the badge images in the database with the unbaked base64 data, flip `baked` bit to 0. I use Sequel Pro for this.
4. Hard-refresh the page and see if the badge image shows up
5. For extra credit, examine the database and ensure the image data is actually different: copy the base64 data from the databse, then `pbpaste | base64 -D | diff static/_demo/zero.large.png -`
