### PR TITLE
Adds CSS to fix #971: huge badge images in groups

### DIFF
--- a/static/less/backpack.less
+++ b/static/less/backpack.less
@@ -122,6 +122,12 @@ form.baker #assertion {
   cursor: pointer;
 }
 
+.openbadge img {
+  /* fixes IE8 massive img in collection bug: https://github.com/mozilla/openbadges/issues/971 */
+  max-width: none;
+  width: 64px;
+}
+
 .openbadge:active {
   outline: none;
 }


### PR DESCRIPTION
Closes #971. IE8 seems to hate `max-width` and want `width` in CSS, not just as an attribute.

Unrelated, why is there no :shrug: emoji?!
