### PR TITLE
Upgrade validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nunjucks": "~0.1.10",
     "underscore": "~1.3.3",
     "optimist": "~0.3.0",
-    "openbadges-validator": "0.2.2",
+    "openbadges-validator": "0.2.3",
     "openbadges-bakery": "1.0.2",
     "newrelic": "~0.10.3",
     "async": "~0.2.6",


### PR DESCRIPTION
Includes validator fix that makes salt optional. Helps close mozilla/openbadger#328.
