### PR TITLE
Bake original assertion or signature

### DIFF
--- a/controllers/backpack.js
+++ b/controllers/backpack.js
@@ -435,9 +435,9 @@ exports.userBadgeUpload = function userBadgeUpload(req, res) {
       awardOptions[data.type] = data.value;
       analyzeAssertion(data.value, callback);
     },
-    function confirmAndAward(info, callback) {
+    function confirmAndAward(data, callback) {
       const recipient = awardOptions.recipient;
-      const assertion = normalizeAssertion(info);
+      const assertion = normalizeAssertion(data.info);
       const userOwnsBadge = Badge.confirmRecipient(assertion, recipient);
       if (!userOwnsBadge) {
         const err = new Error('This badge was not issued to you! Contact your issuer.');

--- a/controllers/baker.js
+++ b/controllers/baker.js
@@ -45,10 +45,10 @@ exports.baker = function (req, res) {
       awardOptions.url = url;
       analyzeAssertion(url, callback)
     },
-    function bakeBadge(info, callback) {
-      var image = preferredImage(info.resources)
-      var assertion = info.structures.assertion;
-      awardOptions.assertion = info.structures.assertion;
+    function bakeBadge(data, callback) {
+      var image = preferredImage(data.info.resources)
+      var assertion = data.info.structures.assertion;
+      awardOptions.assertion = data.info.structures.assertion;
 
       if (!assertion.verify) {
         assertion = xtend(assertion, {

--- a/controllers/issuer.js
+++ b/controllers/issuer.js
@@ -191,7 +191,7 @@ exports.issuerBadgeAddFromAssertion = function (req, res, next) {
       return res.json(400, err);
     }
 
-    const assertion = normalizeAssertion(data);
+    const assertion = normalizeAssertion(data.info);
     const recipient = user.get('email');
     const userOwnsBadge = Badge.confirmRecipient(assertion, recipient);
     const origin = assertion.badge.issuer.origin;
@@ -210,8 +210,9 @@ exports.issuerBadgeAddFromAssertion = function (req, res, next) {
 
     // awarding the badge, only done if this is a POST
     if (req.method == 'POST') {
-      const imagedata = data.resources['badge.image'];
+      const imagedata = data.info.resources['badge.image'];
       const opts = {
+        original: data.assertion,
         assertion: assertion,
         imagedata: imagedata,
         recipient: recipient,

--- a/lib/analyze-assertion.js
+++ b/lib/analyze-assertion.js
@@ -49,11 +49,15 @@ module.exports = function analyze(thing, callback) {
     return getAssertion(thing, function (error, assertion) {
       if (error)
         return callback(error);
-      return validator(assertion, callback)
+      return validator(assertion, function(err, info){
+        callback(err, {assertion: assertion, info: info});
+      });
     });
   }
   if (isObject(thing) || validator.isSignedBadge(thing))
-    return validator(thing, callback);
+    return validator(thing, function(err, info){
+      callback(err, {assertion: thing, info: info});
+    });
   return callback(makeError({
     name: 'TypeError',
     message: 'invalid input: requires valid url, assertion, or signature',

--- a/lib/award.js
+++ b/lib/award.js
@@ -84,7 +84,7 @@ function createBakeryOptions(opts) {
     return result
   }
 
-  var assertion = opts.assertion
+  var assertion = opts.original || opts.assertion;
 
   // pre-1.0.0 assertions did not have a verify structure and we need
   // one for baking, so what we're gonna do here is just create one and

--- a/test/analyze-assertion.test.js
+++ b/test/analyze-assertion.test.js
@@ -8,9 +8,9 @@ const analyzeAssertion = require('../lib/analyze-assertion');
 
 test('analyzeAssertion: valid old assertion', function (t) {
   $.mockHttp();
-  analyzeAssertion($.makeOldAssertion(), function (err, info) {
+  analyzeAssertion($.makeOldAssertion(), function (err, data) {
     t.notOk(err, 'no errors');
-    t.same(info.version, '0.5.0');
+    t.same(data.info.version, '0.5.0');
     t.end();
   });
 });
@@ -20,7 +20,7 @@ test('analyzeAssertion: invalid old assertion, bad form', function (t) {
   const assertion = $.makeOldAssertion();
   delete assertion.badge.criteria;
   delete assertion.badge.image;
-  analyzeAssertion(assertion, function (err, info) {
+  analyzeAssertion(assertion, function (err, data) {
     t.same(err.code, 'structure');
     t.ok(err.extra['badge.image'], 'should have image error');
     t.end();
@@ -31,16 +31,16 @@ test('analyzeAssertion: valid old assertion, url', function (t) {
   const assertion = $.makeOldAssertion();
   $.mockHttp()
     .get('/assertion').reply(200, JSON.stringify(assertion), { 'content-type': 'application/json' })
-  analyzeAssertion($.makeUrl('/assertion'), function (err, info) {
+  analyzeAssertion($.makeUrl('/assertion'), function (err, data) {
     t.notOk(err, 'no errors');
-    t.same(info.version, '0.5.0');
-    t.same(info.structures.assertion, assertion);
+    t.same(data.info.version, '0.5.0');
+    t.same(data.info.structures.assertion, assertion);
     t.end();
   });
 });
 
 test('analyzeAssertion: url points to nothing', function (t) {
-  analyzeAssertion('https://not-a-real-domain.fake', function (err, info) {
+  analyzeAssertion('https://not-a-real-domain.fake', function (err, data) {
     t.same(err.code, 'http-unreachable');
     t.end();
   });
@@ -51,18 +51,18 @@ test('analyzeAssertion: bad responses', function (t) {
     .get('/404').reply(404)
     .get('/500').reply(500)
   t.plan(4);
-  analyzeAssertion($.makeUrl('/404'), function (err, info) {
+  analyzeAssertion($.makeUrl('/404'), function (err, data) {
     t.same(err.code, 'http-status');
     t.same(err.extra, 404);
   });
-  analyzeAssertion($.makeUrl('/500'), function (err, info) {
+  analyzeAssertion($.makeUrl('/500'), function (err, data) {
     t.same(err.code, 'http-status');
     t.same(err.extra, 500);
   });
 });
 
 test('analyzeAssertion: malformed url', function (t) {
-  analyzeAssertion('something not a url', function (err, info) {
+  analyzeAssertion('something not a url', function (err, data) {
     t.same(err.name, 'TypeError');
     t.end();
   });
@@ -72,21 +72,21 @@ test('analyzeAssertion: new assertion, hosted', function (t) {
   const assertion = $.makeNewAssertion();
   $.mockHttp()
     .get('/assertion').reply(200, JSON.stringify(assertion))
-  analyzeAssertion(assertion, function (err, info) {
+  analyzeAssertion(assertion, function (err, data) {
     t.notOk(err, 'no errors')
-    t.same(info.version, '1.0.0');
-    t.same(info.structures.assertion, assertion);
+    t.same(data.info.version, '1.0.0');
+    t.same(data.info.structures.assertion, assertion);
     t.end();
   });
 });
 
 test('analyzeAssertion: new assertion, signed', function (t) {
   const signature = $.makeSignature();
-  analyzeAssertion(signature, function (err, info) {
+  analyzeAssertion(signature, function (err, data) {
     t.notOk(err, 'no errors');
-    t.same(info.version, '1.0.0');
-    t.same(signature, info.signature);
-    t.same(info.structures.assertion.uid, 'f2c20');
+    t.same(data.info.version, '1.0.0');
+    t.same(signature, data.info.signature);
+    t.same(data.info.structures.assertion.uid, 'f2c20');
     t.end();
   });
 });


### PR DESCRIPTION
Changes `analyze-assertion.js` to pass through the original fetched assertion or signature, and uses that in baking rather than the normalized assertion as per #1029.
