### PR TITLE
adding lower case emails if the assertion isn't a hashed email. 

### DIFF
--- a/models/badge.js
+++ b/models/badge.js
@@ -49,9 +49,9 @@ Badge.confirmRecipient = function confirmRecipient(assertion, email) {
   if (typeof recipient !== 'string')
     return false
 
-  // if it's an email address, do a straight comparison
+  // if it's an email address, do a straight lower-case comparison mozilla/openbadges#469
   if (/@/.test(recipient))
-    return recipient === email;
+    return recipient.toLowerCase() === email.toLowerCase();
 
   // if it's not an email address, it must have an alg and dollar sign.
   if (!(recipient.match(/\w+(\d+)?\$.+/)))


### PR DESCRIPTION
fixes #469.

I think. It looks like the `.toLowerCase` comparison was already being done for hashed emails, this just adds lower case to non-hashed emails. Should fix #469. Would like to write a test to test it, but the testing framework here is old and a little confusing. Just PR'ing for now, will figure out tests in the near future.
