### PR TITLE
Force criteria and evidence links to open in a new window

### DIFF
--- a/views/badge-data.html
+++ b/views/badge-data.html
@@ -54,13 +54,13 @@
     </tr>
     <tr>
       <td class='fieldlabel'>Criteria</td>
-      <td><a href='{{badge.attributes.body.badge.criteria|e}}'>{{badge.attributes.body.badge.criteria|e}}</a></td>
+      <td><a href='{{badge.attributes.body.badge.criteria|e}}' target='_blank'>{{badge.attributes.body.badge.criteria|e}}</a></td>
     </tr>
 
     {% if badge.attributes.body.evidence %}
     <tr>
       <td class='fieldlabel evidence'>Evidence</td>
-      <td><a href='{{badge.attributes.body.evidence|e}}'>{{badge.attributes.body.evidence|e}}</a></td>
+      <td><a href='{{badge.attributes.body.evidence|e}}' target='_blank'>{{badge.attributes.body.evidence|e}}</a></td>
     </tr>
     {% endif %}
 


### PR DESCRIPTION
Refer to issue #991 

Discussion on that issue indicates that this was resolved, but it was not. Since clicking on the Criteria or Evidence links render the Issuer dialog inoperable, I'm submitting this myself